### PR TITLE
remove unneeded volume keyword

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,5 @@
 version: "3.8"
 
-volumes:
-
 services:
   neuters:
     container_name: neuters


### PR DESCRIPTION
The keyword `volumes:` was added in error.

Removed.