### PR TITLE
feat: add setting to set the max number of articles per page

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,7 @@ fn main() {
                     .get("/world/")
                     .unwrap_or_else(|| panic!("Section 'world' not found"));
 
-                render_section(&client, section, offset, 8)
+                render_section(&client, section, offset, settings.article_limit)
             }
             "/about" => render_about(),
             "/settings" => return handle_settings(request, &settings),
@@ -195,7 +195,7 @@ fn main() {
                     let offset = request
                         .get_param("offset")
                         .map_or(0, |s| s.parse::<u32>().unwrap_or(0));
-                    render_section(&client, section, offset, 8)
+                    render_section(&client, section, offset, settings.article_limit)
                 } else if path.starts_with("/authors/") {
                     let offset = request
                         .get_param("offset")

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -5,6 +5,7 @@ pub const EMBED_EMBEDS: &str = "embed_embeds";
 pub const PROXY_IMAGES: &str = "proxy_images";
 pub const FAST_REDIRECT: &str = "fast_redirect";
 pub const REDIRECT_TIMER: &str = "redirect_timer";
+pub const ARTICLE_LIMIT: &str = "article_limit";
 
 pub struct Settings {
     pub embed_images: bool,
@@ -12,6 +13,7 @@ pub struct Settings {
     pub proxy_images: bool,
     pub fast_redirect: bool,
     pub redirect_timer: u32,
+    pub article_limit: u32,
 }
 
 impl Settings {
@@ -21,6 +23,7 @@ impl Settings {
         let mut proxy_images = true;
         let mut fast_redirect = false;
         let mut redirect_timer = 5;
+        let mut article_limit = 8;
         for (key, value) in input::cookies(request) {
             match key {
                 EMBED_IMAGES => embed_images = value == "true",
@@ -28,6 +31,7 @@ impl Settings {
                 PROXY_IMAGES => proxy_images = value == "true",
                 FAST_REDIRECT => fast_redirect = value == "true",
                 REDIRECT_TIMER => redirect_timer = value.parse().unwrap_or(5),
+                ARTICLE_LIMIT => article_limit = value.parse().unwrap_or(5),
                 _ => {}
             }
         }
@@ -38,6 +42,7 @@ impl Settings {
             proxy_images,
             fast_redirect,
             redirect_timer,
+            article_limit
         }
     }
 }


### PR DESCRIPTION
This PR introduces a new `article_limit` setting so you can control how many articles to fetch/display on the home and topic pages from the setting page. By default it remains at 8 (preserving prior behavior), but you can now bump it up (e.g. to 16) or lower it to suit your needs.

**Background**

- The previous implementation hard-coded a limit of 8 articles.
- I often find 16 articles more useful for my liking, so rather than keep hacking the source, this makes it configurable.
